### PR TITLE
Fix #3: Expose CRUD for user claims at REST

### DIFF
--- a/.run/UserDataStoreApplication.run.xml
+++ b/.run/UserDataStoreApplication.run.xml
@@ -1,6 +1,7 @@
 <component name="ProjectRunConfigurationManager">
   <configuration default="false" name="UserDataStoreApplication" type="SpringBootApplicationConfigurationType" factoryName="Spring Boot" nameIsGenerated="true">
     <option name="ACTIVE_PROFILES" value="dev" />
+    <option name="DEBUG_MODE" value="true" />
     <envs>
       <env name="JDBC_DATABASE_SCHEMA" value="powerauth" />
       <env name="JDBC_DATABASE_USERNAME" value="powerauth" />

--- a/lombok.config
+++ b/lombok.config
@@ -1,0 +1,1 @@
+lombok.log.fieldName=logger

--- a/pom.xml
+++ b/pom.xml
@@ -63,6 +63,12 @@
             <artifactId>spring-boot-starter-actuator</artifactId>
         </dependency>
 
+        <dependency>
+            <groupId>org.projectlombok</groupId>
+            <artifactId>lombok</artifactId>
+            <scope>provided</scope>
+        </dependency>
+
         <!-- Documentation -->
         <dependency>
             <groupId>org.springdoc</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -22,6 +22,8 @@
         <maven.deploy.skip>true</maven.deploy.skip>
         <maven.install.skip>true</maven.install.skip>
 
+        <wultra-core.version>1.6.0</wultra-core.version>
+
         <springdoc-openapi.version>1.6.14</springdoc-openapi.version>
     </properties>
 
@@ -67,6 +69,13 @@
             <groupId>org.projectlombok</groupId>
             <artifactId>lombok</artifactId>
             <scope>provided</scope>
+        </dependency>
+
+        <!-- Wultra Dependencies -->
+        <dependency>
+            <groupId>io.getlime.core</groupId>
+            <artifactId>rest-model-base</artifactId>
+            <version>${wultra-core.version}</version>
         </dependency>
 
         <!-- Documentation -->

--- a/pom.xml
+++ b/pom.xml
@@ -21,6 +21,8 @@
         <java.version>17</java.version>
         <maven.deploy.skip>true</maven.deploy.skip>
         <maven.install.skip>true</maven.install.skip>
+
+        <springdoc-openapi.version>1.6.14</springdoc-openapi.version>
     </properties>
 
     <dependencies>
@@ -53,13 +55,21 @@
 
         <dependency>
             <groupId>org.springframework.boot</groupId>
-            <artifactId>spring-boot-starter-test</artifactId>
-            <scope>test</scope>
+            <artifactId>spring-boot-starter-actuator</artifactId>
         </dependency>
 
+        <!-- Documentation -->
+        <dependency>
+            <groupId>org.springdoc</groupId>
+            <artifactId>springdoc-openapi-ui</artifactId>
+            <version>${springdoc-openapi.version}</version>
+        </dependency>
+
+        <!-- Test dependencies -->
         <dependency>
             <groupId>org.springframework.boot</groupId>
-            <artifactId>spring-boot-starter-actuator</artifactId>
+            <artifactId>spring-boot-starter-test</artifactId>
+            <scope>test</scope>
         </dependency>
 
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -38,6 +38,11 @@
 
         <dependency>
             <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-security</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-thymeleaf</artifactId>
         </dependency>
 
@@ -70,6 +75,11 @@
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-test</artifactId>
             <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.springframework.security</groupId>
+            <artifactId>spring-security-test</artifactId>
         </dependency>
 
         <dependency>

--- a/src/main/java/com/wultra/security/userdatastore/OpenApiConfiguration.java
+++ b/src/main/java/com/wultra/security/userdatastore/OpenApiConfiguration.java
@@ -1,0 +1,49 @@
+/*
+ * User Data Store
+ * Copyright (C) 2023 Wultra s.r.o.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package com.wultra.security.userdatastore;
+
+import io.swagger.v3.oas.annotations.OpenAPIDefinition;
+import io.swagger.v3.oas.annotations.info.Contact;
+import io.swagger.v3.oas.annotations.info.Info;
+import io.swagger.v3.oas.annotations.info.License;
+import org.springframework.context.annotation.Configuration;
+
+/**
+ * Configuration class used for setting up Swagger documentation.
+ *
+ * @author Lubos Racansky lubos.racansky@wultra.com
+ */
+@Configuration
+@OpenAPIDefinition(
+        info = @Info(
+                title = "User Data Store API",
+                version = "1.0",
+                license = @License(
+                        name = "AGPL-3.0",
+                        url = "https://www.gnu.org/licenses/agpl-3.0.en.html"
+                ),
+                description = "Documentation for the RESTful API published by the User Data Store.",
+                contact = @Contact(
+                        name = "Wultra s.r.o.",
+                        url = "https://www.wultra.com"
+                )
+        )
+)
+class OpenApiConfiguration {
+
+}

--- a/src/main/java/com/wultra/security/userdatastore/SecurityConfiguration.java
+++ b/src/main/java/com/wultra/security/userdatastore/SecurityConfiguration.java
@@ -1,0 +1,50 @@
+/*
+ * User Data Store
+ * Copyright (C) 2023 Wultra s.r.o.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package com.wultra.security.userdatastore;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.http.HttpMethod;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.web.SecurityFilterChain;
+
+/**
+ * Security configuration class.
+ *
+ * @author Lubos Racansky lubos.racansky@wultra.com
+ */
+@Configuration
+public class SecurityConfiguration {
+
+    @Bean
+    public SecurityFilterChain filterChain(final HttpSecurity http) throws Exception {
+        return http.csrf()
+                .disable()
+                .authorizeRequests()
+                .antMatchers(HttpMethod.DELETE, "/public/**")
+                .hasRole("DELETE")
+                .antMatchers(HttpMethod.POST, "/public/**")
+                .hasRole("WRITE")
+                .antMatchers(HttpMethod.GET, "/private/**")
+                .hasRole("READ")
+                .antMatchers("/swagger-ui*/**")
+                .anonymous()
+                .and()
+                .build();
+    }
+}

--- a/src/main/java/com/wultra/security/userdatastore/SecurityConfiguration.java
+++ b/src/main/java/com/wultra/security/userdatastore/SecurityConfiguration.java
@@ -22,6 +22,7 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.http.HttpMethod;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
 import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.web.SecurityFilterChain;
 
@@ -39,20 +40,18 @@ public class SecurityConfiguration {
     @Bean
     public SecurityFilterChain filterChain(final HttpSecurity http) throws Exception {
         return http
-                .csrf().disable()
-                .sessionManagement().sessionCreationPolicy(SessionCreationPolicy.STATELESS)
-                .and()
+                .csrf(AbstractHttpConfigurer::disable)
+                .sessionManagement(sessionManagement -> sessionManagement.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
                 .httpBasic(httpBasic -> httpBasic.realmName(realm))
-                .authorizeRequests()
-                .antMatchers(HttpMethod.DELETE, "/public/**")
-                .hasRole("DELETE")
-                .antMatchers(HttpMethod.POST, "/public/**")
-                .hasRole("WRITE")
-                .antMatchers(HttpMethod.GET, "/private/**")
-                .hasRole("READ")
-                .antMatchers("/swagger-ui*/**")
-                .anonymous()
-                .and()
-                .build();
+                .authorizeRequests(authorize -> authorize
+                        .antMatchers(HttpMethod.DELETE, "/public/**")
+                            .hasRole("DELETE")
+                        .antMatchers(HttpMethod.POST, "/public/**")
+                            .hasRole("WRITE")
+                        .antMatchers(HttpMethod.GET, "/private/**")
+                            .hasRole("READ")
+                        .antMatchers("/swagger-ui*/**")
+                            .anonymous()
+                ).build();
     }
 }

--- a/src/main/java/com/wultra/security/userdatastore/SecurityConfiguration.java
+++ b/src/main/java/com/wultra/security/userdatastore/SecurityConfiguration.java
@@ -17,10 +17,12 @@
  */
 package com.wultra.security.userdatastore;
 
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.http.HttpMethod;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.web.SecurityFilterChain;
 
 /**
@@ -31,10 +33,16 @@ import org.springframework.security.web.SecurityFilterChain;
 @Configuration
 public class SecurityConfiguration {
 
+    @Value("${user-data-store.security.basic.realm}")
+    private String realm;
+
     @Bean
     public SecurityFilterChain filterChain(final HttpSecurity http) throws Exception {
-        return http.csrf()
-                .disable()
+        return http
+                .csrf().disable()
+                .sessionManagement().sessionCreationPolicy(SessionCreationPolicy.STATELESS)
+                .and()
+                .httpBasic(httpBasic -> httpBasic.realmName(realm))
                 .authorizeRequests()
                 .antMatchers(HttpMethod.DELETE, "/public/**")
                 .hasRole("DELETE")

--- a/src/main/java/com/wultra/security/userdatastore/SecurityConfiguration.java
+++ b/src/main/java/com/wultra/security/userdatastore/SecurityConfiguration.java
@@ -45,7 +45,7 @@ public class SecurityConfiguration {
                 .httpBasic(httpBasic -> httpBasic.realmName(realm))
                 .authorizeRequests(authorize -> authorize
                         .antMatchers(HttpMethod.DELETE, "/public/**")
-                            .hasRole("DELETE")
+                            .hasRole("WRITE")
                         .antMatchers(HttpMethod.POST, "/public/**")
                             .hasRole("WRITE")
                         .antMatchers(HttpMethod.GET, "/private/**")

--- a/src/main/java/com/wultra/security/userdatastore/userclaims/UserClaimsController.java
+++ b/src/main/java/com/wultra/security/userdatastore/userclaims/UserClaimsController.java
@@ -17,9 +17,10 @@
  */
 package com.wultra.security.userdatastore.userclaims;
 
+import io.getlime.core.rest.model.base.response.ObjectResponse;
+import io.getlime.core.rest.model.base.response.Response;
 import io.swagger.v3.oas.annotations.Operation;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.*;
 
 import javax.validation.constraints.NotBlank;
@@ -51,9 +52,10 @@ class UserClaimsController {
             description = "Return claims for the given user."
     )
     @GetMapping("/private/user-claims")
-    public Object userClaims(@NotBlank @Size(max = 255) @RequestParam String userId) {
+    public ObjectResponse<Object> userClaims(@NotBlank @Size(max = 255) @RequestParam String userId) {
         logger.info("Fetching claims of user ID: {}", userId);
-        return userClaimsService.fetchUserClaims(userId);
+        final Object userClaims = userClaimsService.fetchUserClaims(userId);
+        return new ObjectResponse<>(userClaims);
     }
 
     /**
@@ -61,31 +63,33 @@ class UserClaimsController {
      *
      * @param userId user identifier
      * @param claims claims to be stored
+     * @return response status
      */
     @Operation(
             summary = "Create or update claims",
             description = "Create claims for the given user or update the exiting ones."
     )
     @PostMapping("/public/user-claims")
-    @ResponseStatus(HttpStatus.CREATED)
-    public void createOrUpdate(@NotBlank @Size(max = 255) @RequestParam String userId, @RequestBody final Object claims) {
+    public Response createOrUpdate(@NotBlank @Size(max = 255) @RequestParam String userId, @RequestBody final Object claims) {
         logger.info("Creating or updating claims of user ID: {}", userId);
         userClaimsService.createOrUpdateUserClaims(userId, claims);
+        return new Response();
     }
 
     /**
      * Delete claims of the given user.
      *
      * @param userId user identifier
+     * @return response status
      */
     @Operation(
             summary = "Delete claims",
             description = "Delete claims of the given user."
     )
     @DeleteMapping("/public/user-claims")
-    @ResponseStatus(HttpStatus.NO_CONTENT)
-    public void delete(@NotBlank @Size(max = 255) @RequestParam String userId) {
+    public Response delete(@NotBlank @Size(max = 255) @RequestParam String userId) {
         logger.info("Deleting claims of user ID: {}", userId);
         userClaimsService.deleteUserClaims(userId);
+        return new Response();
     }
 }

--- a/src/main/java/com/wultra/security/userdatastore/userclaims/UserClaimsController.java
+++ b/src/main/java/com/wultra/security/userdatastore/userclaims/UserClaimsController.java
@@ -17,6 +17,7 @@
  */
 package com.wultra.security.userdatastore.userclaims;
 
+import io.swagger.v3.oas.annotations.Operation;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.http.HttpStatus;
@@ -44,6 +45,10 @@ class UserClaimsController {
      * @param userId user identifier
      * @return user claims
      */
+    @Operation(
+            summary = "Return claims",
+            description = "Return claims for the given user."
+    )
     @GetMapping("/private/user/{userId}/claims")
     public Object userClaims(@PathVariable final String userId) {
         logger.info("Fetching claims of user ID: {}", userId);
@@ -56,6 +61,10 @@ class UserClaimsController {
      * @param userId user identifier
      * @param claims claims to be stored
      */
+    @Operation(
+            summary = "Create or update claims",
+            description = "Create claims for the given user or update the exiting ones."
+    )
     @PostMapping("/public/user/{userId}/claims")
     @ResponseStatus(HttpStatus.CREATED)
     public void createOrUpdate(@PathVariable final String userId, @RequestBody final Object claims) {
@@ -68,6 +77,10 @@ class UserClaimsController {
      *
      * @param userId user identifier
      */
+    @Operation(
+            summary = "Delete claims",
+            description = "Delete claims of the given user."
+    )
     @DeleteMapping("/public/user/{userId}/claims")
     @ResponseStatus(HttpStatus.NO_CONTENT)
     public void delete(@PathVariable final String userId) {

--- a/src/main/java/com/wultra/security/userdatastore/userclaims/UserClaimsController.java
+++ b/src/main/java/com/wultra/security/userdatastore/userclaims/UserClaimsController.java
@@ -18,8 +18,7 @@
 package com.wultra.security.userdatastore.userclaims;
 
 import io.swagger.v3.oas.annotations.Operation;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.*;
 
@@ -32,9 +31,8 @@ import javax.validation.constraints.Size;
  * @author Lubos Racansky lubos.racansky@wultra.com
  */
 @RestController
+@Slf4j
 class UserClaimsController {
-
-    private static final Logger logger = LoggerFactory.getLogger(UserClaimsController.class);
 
     private final UserClaimsService userClaimsService;
 

--- a/src/main/java/com/wultra/security/userdatastore/userclaims/UserClaimsController.java
+++ b/src/main/java/com/wultra/security/userdatastore/userclaims/UserClaimsController.java
@@ -23,6 +23,9 @@ import org.slf4j.LoggerFactory;
 import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.*;
 
+import javax.validation.constraints.NotBlank;
+import javax.validation.constraints.Size;
+
 /**
  * REST controller providing API for CRUD of user claims.
  *
@@ -49,8 +52,8 @@ class UserClaimsController {
             summary = "Return claims",
             description = "Return claims for the given user."
     )
-    @GetMapping("/private/user/{userId}/claims")
-    public Object userClaims(@PathVariable final String userId) {
+    @GetMapping("/private/user-claims")
+    public Object userClaims(@NotBlank @Size(max = 255) @RequestParam String userId) {
         logger.info("Fetching claims of user ID: {}", userId);
         return userClaimsService.fetchUserClaims(userId);
     }
@@ -65,9 +68,9 @@ class UserClaimsController {
             summary = "Create or update claims",
             description = "Create claims for the given user or update the exiting ones."
     )
-    @PostMapping("/public/user/{userId}/claims")
+    @PostMapping("/public/user-claims")
     @ResponseStatus(HttpStatus.CREATED)
-    public void createOrUpdate(@PathVariable final String userId, @RequestBody final Object claims) {
+    public void createOrUpdate(@NotBlank @Size(max = 255) @RequestParam String userId, @RequestBody final Object claims) {
         logger.info("Creating or updating claims of user ID: {}", userId);
         userClaimsService.createOrUpdateUserClaims(userId, claims);
     }
@@ -81,9 +84,9 @@ class UserClaimsController {
             summary = "Delete claims",
             description = "Delete claims of the given user."
     )
-    @DeleteMapping("/public/user/{userId}/claims")
+    @DeleteMapping("/public/user-claims")
     @ResponseStatus(HttpStatus.NO_CONTENT)
-    public void delete(@PathVariable final String userId) {
+    public void delete(@NotBlank @Size(max = 255) @RequestParam String userId) {
         logger.info("Deleting claims of user ID: {}", userId);
         userClaimsService.deleteUserClaims(userId);
     }

--- a/src/main/java/com/wultra/security/userdatastore/userclaims/UserClaimsController.java
+++ b/src/main/java/com/wultra/security/userdatastore/userclaims/UserClaimsController.java
@@ -1,0 +1,77 @@
+/*
+ * User Data Store
+ * Copyright (C) 2023 Wultra s.r.o.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package com.wultra.security.userdatastore.userclaims;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.*;
+
+/**
+ * REST controller providing API for CRUD of user claims.
+ *
+ * @author Lubos Racansky lubos.racansky@wultra.com
+ */
+@RestController
+class UserClaimsController {
+
+    private static final Logger logger = LoggerFactory.getLogger(UserClaimsController.class);
+
+    private final UserClaimsService userClaimsService;
+
+    UserClaimsController(UserClaimsService userClaimsService) {
+        this.userClaimsService = userClaimsService;
+    }
+
+    /**
+     * Return claims for the given user.
+     *
+     * @param userId user identifier
+     * @return user claims
+     */
+    @GetMapping("/private/user/{userId}/claims")
+    public Object userClaims(@PathVariable final String userId) {
+        logger.info("Fetching claims of user ID: {}", userId);
+        return userClaimsService.fetchUserClaims(userId);
+    }
+
+    /**
+     * Create claims for the given user or update the exiting ones.
+     *
+     * @param userId user identifier
+     * @param claims claims to be stored
+     */
+    @PostMapping("/public/user/{userId}/claims")
+    @ResponseStatus(HttpStatus.CREATED)
+    public void createOrUpdate(@PathVariable final String userId, @RequestBody final Object claims) {
+        logger.info("Creating or updating claims of user ID: {}", userId);
+        userClaimsService.createOrUpdateUserClaims(userId, claims);
+    }
+
+    /**
+     * Delete claims of the given user.
+     *
+     * @param userId user identifier
+     */
+    @DeleteMapping("/public/user/{userId}/claims")
+    @ResponseStatus(HttpStatus.NO_CONTENT)
+    public void delete(@PathVariable final String userId) {
+        logger.info("Deleting claims of user ID: {}", userId);
+        userClaimsService.deleteUserClaims(userId);
+    }
+}

--- a/src/main/java/com/wultra/security/userdatastore/userclaims/UserClaimsService.java
+++ b/src/main/java/com/wultra/security/userdatastore/userclaims/UserClaimsService.java
@@ -15,21 +15,33 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
-package com.wultra.security.userdatastore;
+package com.wultra.security.userdatastore.userclaims;
 
-import org.junit.jupiter.api.Test;
-import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.stereotype.Service;
+
+import java.util.HashMap;
+import java.util.Map;
 
 /**
- * Test of spring context start.
+ * Service for user claims.
  *
  * @author Lubos Racansky lubos.racansky@wultra.com
  */
-@SpringBootTest
-class UserDataStoreApplicationTests {
+@Service
+class UserClaimsService {
 
-	@Test
-	void contextLoads() {
-	}
+    // TODO (racansky, 2023-02-17, #4) implement persistence
+    private static final Map<String, Object> data = new HashMap<>();
 
+    public Object fetchUserClaims(final String userId) {
+        return data.get(userId);
+    }
+
+    public void createOrUpdateUserClaims(final String userId, final Object claims) {
+        data.put(userId, claims);
+    }
+
+    public void deleteUserClaims(final String userId) {
+        data.remove(userId);
+    }
 }

--- a/src/main/resources/application-dev.properties
+++ b/src/main/resources/application-dev.properties
@@ -6,3 +6,7 @@ spring.jpa.database-platform=org.hibernate.dialect.PostgreSQLDialect
 spring.jpa.properties.hibernate.temp.use_jdbc_metadata_defaults=false
 spring.jpa.properties.hibernate.connection.characterEncoding=utf8
 spring.jpa.properties.hibernate.connection.useUnicode=true
+
+# TODO (racansky, 2023-02-20, #4) implement persistence
+spring.security.user.roles=READ,WRITE,DELETE
+spring.security.user.password=password

--- a/src/main/resources/application-dev.properties
+++ b/src/main/resources/application-dev.properties
@@ -8,5 +8,5 @@ spring.jpa.properties.hibernate.connection.characterEncoding=utf8
 spring.jpa.properties.hibernate.connection.useUnicode=true
 
 # TODO (racansky, 2023-02-20, #4) implement persistence
-spring.security.user.roles=READ,WRITE,DELETE
+spring.security.user.roles=READ,WRITE
 spring.security.user.password=password

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -4,3 +4,5 @@ spring.jpa.hibernate.ddl-auto=none
 spring.jpa.open-in-view=false
 
 spring.jmx.default-domain=user-data-store
+
+user-data-store.security.basic.realm=User Data Store

--- a/src/main/resources/templates/index.html
+++ b/src/main/resources/templates/index.html
@@ -24,10 +24,18 @@
 </head>
 <body>
 <h1>User Data Store</h1>
+
+<h2>System Information</h2>
 <p>
     Version <span th:text="${version}">version</span><span th:if="${built != 'UNKNOWN'}">, built on
     <span th:text="${#dates.format(built, 'yyyy/MM/dd, HH:mm:ss')}">built</span>.</span>
 </p>
+
+<h2>Available Interfaces</h2>
+<ul>
+    <li><a href="swagger-ui.html">User Data Store RESTful API</a></li>
+</ul>
+
 <p>
     <span th:if="${built != 'UNKNOWN'}">
         <span th:text="${#dates.format(built, 'yyyy')}"></span>,

--- a/src/test/java/com/wultra/security/userdatastore/userclaims/UserClaimsControllerTest.java
+++ b/src/test/java/com/wultra/security/userdatastore/userclaims/UserClaimsControllerTest.java
@@ -73,7 +73,7 @@ class UserClaimsControllerTest {
                 .andExpect(jsonPath("$.name", is("Alice Adams")));
     }
 
-    @WithMockUser(roles = {"DELETE", "WRITE"})
+    @WithMockUser(roles = "WRITE")
     @Test
     void testGet_wrongRoles() throws Exception {
         mvc.perform(get("/private/user-claims?userId=alice")
@@ -81,7 +81,7 @@ class UserClaimsControllerTest {
                 .andExpect(status().isForbidden());
     }
 
-    @WithMockUser(roles = "DELETE")
+    @WithMockUser(roles = "WRITE")
     @Test
     void testDelete() throws Exception {
         mvc.perform(delete("/public/user-claims?userId=alice"))
@@ -90,7 +90,7 @@ class UserClaimsControllerTest {
         verify(service).deleteUserClaims("alice");
     }
 
-    @WithMockUser(roles = {"WRITE", "READ"})
+    @WithMockUser(roles = "READ")
     @Test
     void testDelete_wrongRoles() throws Exception {
         mvc.perform(delete("/public/user-claims?userId=alice"))
@@ -123,7 +123,7 @@ class UserClaimsControllerTest {
         verify(service).createOrUpdateUserClaims("alice", expectedClaims);
     }
 
-    @WithMockUser(roles = {"DELETE", "READ"})
+    @WithMockUser(roles = "READ")
     @Test
     void testPost_wrongRoles() throws Exception {
         mvc.perform(post("/public/user-claims?userId=alice")

--- a/src/test/java/com/wultra/security/userdatastore/userclaims/UserClaimsControllerTest.java
+++ b/src/test/java/com/wultra/security/userdatastore/userclaims/UserClaimsControllerTest.java
@@ -1,0 +1,103 @@
+/*
+ * User Data Store
+ * Copyright (C) 2023 Wultra s.r.o.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package com.wultra.security.userdatastore.userclaims;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.util.Map;
+
+import static org.hamcrest.Matchers.is;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+/**
+ * Test for {@link UserClaimsController}.
+ *
+ * @author Lubos Racansky lubos.racansky@wultra.com
+ */
+@WebMvcTest(UserClaimsController.class)
+class UserClaimsControllerTest {
+
+    @MockBean
+    private UserClaimsService service;
+
+    @Autowired
+    private MockMvc mvc;
+
+    @Test
+    void testGet() throws Exception {
+        when(service.fetchUserClaims("alice"))
+                .thenReturn("""
+                        {
+                          "sub": "83692",
+                          "name": "Alice Adams",
+                          "email": "alice@example.com",
+                          "birthdate": "1975-12-31",
+                          "https://claims.example.com/department": "engineering"
+                        }
+                        """);
+
+        mvc.perform(get("/private/user/alice/claims")
+                        .accept(MediaType.APPLICATION_JSON))
+                .andExpect(status().isOk())
+                .andExpect(content()
+                        .contentTypeCompatibleWith(MediaType.APPLICATION_JSON))
+                .andExpect(jsonPath("$.name", is("Alice Adams")));
+    }
+
+    @Test
+    void testDelete() throws Exception {
+        mvc.perform(delete("/public/user/alice/claims"))
+                .andExpect(status().is(HttpStatus.NO_CONTENT.value()));
+
+        verify(service).deleteUserClaims("alice");
+    }
+
+    @Test
+    void testPost() throws Exception {
+        mvc.perform(post("/public/user/alice/claims")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {
+                                  "sub": "83692",
+                                  "name": "Alice Adams",
+                                  "email": "alice@example.com",
+                                  "birthdate": "1975-12-31",
+                                  "https://claims.example.com/department": "engineering"
+                                }
+                                """))
+                .andExpect(status().is(HttpStatus.CREATED.value()));
+
+        final var expectedClaims = Map.of(
+                "sub", "83692",
+                "name", "Alice Adams",
+                "email", "alice@example.com",
+                "birthdate", "1975-12-31",
+                "https://claims.example.com/department", "engineering"
+        );
+        verify(service).createOrUpdateUserClaims("alice", expectedClaims);
+    }
+}

--- a/src/test/java/com/wultra/security/userdatastore/userclaims/UserClaimsControllerTest.java
+++ b/src/test/java/com/wultra/security/userdatastore/userclaims/UserClaimsControllerTest.java
@@ -65,7 +65,7 @@ class UserClaimsControllerTest {
                         }
                         """);
 
-        mvc.perform(get("/private/user/alice/claims")
+        mvc.perform(get("/private/user-claims?userId=alice")
                         .accept(MediaType.APPLICATION_JSON))
                 .andExpect(status().isOk())
                 .andExpect(content()
@@ -76,7 +76,7 @@ class UserClaimsControllerTest {
     @WithMockUser(roles = {"DELETE", "WRITE"})
     @Test
     void testGet_wrongRoles() throws Exception {
-        mvc.perform(get("/private/user/alice/claims")
+        mvc.perform(get("/private/user-claims?userId=alice")
                         .accept(MediaType.APPLICATION_JSON))
                 .andExpect(status().isForbidden());
     }
@@ -84,7 +84,7 @@ class UserClaimsControllerTest {
     @WithMockUser(roles = "DELETE")
     @Test
     void testDelete() throws Exception {
-        mvc.perform(delete("/public/user/alice/claims"))
+        mvc.perform(delete("/public/user-claims?userId=alice"))
                 .andExpect(status().is(HttpStatus.NO_CONTENT.value()));
 
         verify(service).deleteUserClaims("alice");
@@ -93,14 +93,14 @@ class UserClaimsControllerTest {
     @WithMockUser(roles = {"WRITE", "READ"})
     @Test
     void testDelete_wrongRoles() throws Exception {
-        mvc.perform(delete("/public/user/alice/claims"))
+        mvc.perform(delete("/public/user-claims?userId=alice"))
                 .andExpect(status().isForbidden());
     }
 
     @WithMockUser(roles = "WRITE")
     @Test
     void testPost() throws Exception {
-        mvc.perform(post("/public/user/alice/claims")
+        mvc.perform(post("/public/user-claims?userId=alice")
                         .contentType(MediaType.APPLICATION_JSON)
                         .content("""
                                 {
@@ -126,7 +126,7 @@ class UserClaimsControllerTest {
     @WithMockUser(roles = {"DELETE", "READ"})
     @Test
     void testPost_wrongRoles() throws Exception {
-        mvc.perform(post("/public/user/alice/claims")
+        mvc.perform(post("/public/user-claims?userId=alice")
                         .contentType(MediaType.APPLICATION_JSON)
                         .content("{}"))
                 .andExpect(status().isForbidden());


### PR DESCRIPTION
Generated open API
```yaml
openapi: 3.0.1
info:
  title: User Data Store API
  description: Documentation for the RESTful API published by the User Data Store.
  contact:
    name: Wultra s.r.o.
    url: https://www.wultra.com
  license:
    name: AGPL-3.0
    url: https://www.gnu.org/licenses/agpl-3.0.en.html
  version: "1.0"
servers:
- url: http://127.0.0.1:8091/user-data-store
  description: Generated server url
paths:
  /public/user-claims:
    post:
      tags:
      - user-claims-controller
      summary: Create or update claims
      description: Create claims for the given user or update the exiting ones.
      operationId: createOrUpdate
      parameters:
      - name: userId
        in: query
        required: true
        schema:
          maxLength: 255
          minLength: 0
          type: string
      requestBody:
        content:
          application/json:
            schema:
              type: object
        required: true
      responses:
        "200":
          description: OK
          content:
            '*/*':
              schema:
                $ref: '#/components/schemas/Response'
    delete:
      tags:
      - user-claims-controller
      summary: Delete claims
      description: Delete claims of the given user.
      operationId: delete
      parameters:
      - name: userId
        in: query
        required: true
        schema:
          maxLength: 255
          minLength: 0
          type: string
      responses:
        "200":
          description: OK
          content:
            '*/*':
              schema:
                $ref: '#/components/schemas/Response'
  /private/user-claims:
    get:
      tags:
      - user-claims-controller
      summary: Return claims
      description: Return claims for the given user.
      operationId: userClaims
      parameters:
      - name: userId
        in: query
        required: true
        schema:
          maxLength: 255
          minLength: 0
          type: string
      responses:
        "200":
          description: OK
          content:
            '*/*':
              schema:
                $ref: '#/components/schemas/ObjectResponseObject'
components:
  schemas:
    Response:
      required:
      - status
      type: object
      properties:
        status:
          type: string
    ObjectResponseObject:
      required:
      - responseObject
      - status
      type: object
      properties:
        status:
          type: string
        responseObject:
          type: object
```