### PR TITLE
Revert "Fix #275: Build and deploy docker image workflow fails (#276)"

### DIFF
--- a/.github/workflows/publish-docker-image.yml
+++ b/.github/workflows/publish-docker-image.yml
@@ -50,8 +50,6 @@ jobs:
         mvn -U -DuseInternalRepo=true --no-transfer-progress package
     - name: Set up QEMU
       uses: docker/setup-qemu-action@v3
-      with:
-        image: tonistiigi/binfmt:qemu-v7.0.0-28 # Workaround until it is fixed in docker/setup-qemu-action repo
     - name: Set up Docker Buildx
       uses: docker/setup-buildx-action@v3
       with:


### PR DESCRIPTION
This reverts commit 2c4ca793b1cd01632095ca17dea7e85f80ecc2a7.