### PR TITLE
Fix #384: Docker image failing to start on 1.5.0

### DIFF
--- a/docs/db/changelog/changesets/user-data-store/1.3.x/20240514-refactor-uds-1.3.0.xml
+++ b/docs/db/changelog/changesets/user-data-store/1.3.x/20240514-refactor-uds-1.3.0.xml
@@ -3,7 +3,7 @@
                    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
                    xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-4.9.xsd">
 
-    <changeSet id="1" author="Roman Strobl">
+    <changeSet id="1" logicalFilePath="user-data-store/1.3.x/20240514-refactor-uds-1.3.0.xml" author="Roman Strobl">
         <preConditions onFail="MARK_RAN">
             <not>
                 <tableExists tableName="uds_document"/>
@@ -38,7 +38,7 @@
         </createTable>
     </changeSet>
 
-    <changeSet id="2" author="Roman Strobl">
+    <changeSet id="2" logicalFilePath="user-data-store/1.3.x/20240514-refactor-uds-1.3.0.xml" author="Roman Strobl">
         <preConditions onFail="MARK_RAN">
             <not>
                 <tableExists tableName="uds_document_history"/>
@@ -75,7 +75,7 @@
         </createTable>
     </changeSet>
 
-    <changeSet id="3" author="Roman Strobl">
+    <changeSet id="3" logicalFilePath="user-data-store/1.3.x/20240514-refactor-uds-1.3.0.xml" author="Roman Strobl">
         <preConditions onFail="MARK_RAN">
             <not>
                 <tableExists tableName="uds_photo"/>
@@ -106,7 +106,7 @@
         </createTable>
     </changeSet>
 
-    <changeSet id="4" author="Roman Strobl">
+    <changeSet id="4" logicalFilePath="user-data-store/1.3.x/20240514-refactor-uds-1.3.0.xml" author="Roman Strobl">
         <preConditions onFail="MARK_RAN">
             <not>
                 <foreignKeyConstraintExists foreignKeyName="fk_uds_photo_document_id" />
@@ -120,7 +120,7 @@
                 referencedColumnNames="id"/>
     </changeSet>
 
-    <changeSet id="5" author="Roman Strobl">
+    <changeSet id="5" logicalFilePath="user-data-store/1.3.x/20240514-refactor-uds-1.3.0.xml" author="Roman Strobl">
         <preConditions onFail="MARK_RAN">
             <not>
                 <tableExists tableName="uds_attachment"/>
@@ -151,7 +151,7 @@
         </createTable>
     </changeSet>
 
-    <changeSet id="6" author="Roman Strobl">
+    <changeSet id="6" logicalFilePath="user-data-store/1.3.x/20240514-refactor-uds-1.3.0.xml" author="Roman Strobl">
         <preConditions onFail="MARK_RAN">
             <not>
                 <foreignKeyConstraintExists foreignKeyName="fk_uds_attachment_document_id" />

--- a/docs/db/changelog/changesets/user-data-store/1.3.x/20240614-migrate-data-1.3.0.xml
+++ b/docs/db/changelog/changesets/user-data-store/1.3.x/20240614-migrate-data-1.3.0.xml
@@ -3,13 +3,13 @@
                    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
                    xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-4.9.xsd">
 
-    <changeSet id="1" author="Roman Strobl" dbms="postgresql">
+    <changeSet id="1" logicalFilePath="user-data-store/1.3.x/20240614-migrate-data-1.3.0.xml" author="Roman Strobl" dbms="postgresql">
         <sql>
             CREATE EXTENSION IF NOT EXISTS "uuid-ossp";
         </sql>
     </changeSet>
 
-    <changeSet id="2" author="Roman Strobl" dbms="postgresql">
+    <changeSet id="2" logicalFilePath="user-data-store/1.3.x/20240614-migrate-data-1.3.0.xml" author="Roman Strobl" dbms="postgresql">
         <preConditions onFail="MARK_RAN">
             <sqlCheck expectedResult="0">
                 SELECT COUNT(*) FROM uds_document;
@@ -46,7 +46,7 @@
         </sql>
     </changeSet>
 
-    <changeSet id="3" author="Roman Strobl" dbms="oracle">
+    <changeSet id="3" logicalFilePath="user-data-store/1.3.x/20240614-migrate-data-1.3.0.xml" author="Roman Strobl" dbms="oracle">
         <sql>
             CREATE OR REPLACE FUNCTION uuid_generate_v4
                 RETURN RAW IS
@@ -58,7 +58,7 @@
         </sql>
     </changeSet>
 
-    <changeSet id="4" author="Roman Strobl" dbms="oracle">
+    <changeSet id="4" logicalFilePath="user-data-store/1.3.x/20240614-migrate-data-1.3.0.xml" author="Roman Strobl" dbms="oracle">
         <preConditions onFail="MARK_RAN">
             <sqlCheck expectedResult="0">
                 SELECT COUNT(*) FROM uds_document;

--- a/docs/db/changelog/changesets/user-data-store/1.3.x/20240812-import-result.xml
+++ b/docs/db/changelog/changesets/user-data-store/1.3.x/20240812-import-result.xml
@@ -3,7 +3,12 @@
                    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
                    xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-4.9.xsd">
 
-    <changeSet id="1" author="Roman Strobl">
+    <changeSet id="1" logicalFilePath="user-data-store/1.3.x/20240812-import-result.xml" author="Roman Strobl">
+        <preConditions onFail="MARK_RAN">
+            <not>
+                <tableExists tableName="uds_import_result"/>
+            </not>
+        </preConditions>
         <createTable tableName="uds_import_result">
             <column name="id" type="VARCHAR(36)">
                 <constraints primaryKey="true" nullable="false"/>

--- a/pom.xml
+++ b/pom.xml
@@ -29,7 +29,7 @@
 
     <groupId>com.wultra.security</groupId>
     <artifactId>user-data-store</artifactId>
-    <version>1.5.0</version>
+    <version>1.5.1</version>
     <packaging>pom</packaging>
     <name>user-data-store</name>
     <description>Storage of user data</description>

--- a/user-data-store-client-model/pom.xml
+++ b/user-data-store-client-model/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>com.wultra.security</groupId>
         <artifactId>user-data-store</artifactId>
-        <version>1.5.0</version>
+        <version>1.5.1</version>
     </parent>
 
     <artifactId>user-data-store-client-model</artifactId>

--- a/user-data-store-rest-client/pom.xml
+++ b/user-data-store-rest-client/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>com.wultra.security</groupId>
         <artifactId>user-data-store</artifactId>
-        <version>1.5.0</version>
+        <version>1.5.1</version>
     </parent>
 
     <artifactId>user-data-store-rest-client</artifactId>

--- a/user-data-store-server/pom.xml
+++ b/user-data-store-server/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>com.wultra.security</groupId>
         <artifactId>user-data-store</artifactId>
-        <version>1.5.0</version>
+        <version>1.5.1</version>
     </parent>
 
     <artifactId>user-data-store-server</artifactId>


### PR DESCRIPTION
I fixed the Liquibase migration due to changing paths because of missing `logicalFilePath` and one missing pre-condition.