### PR TITLE
Fix #434: Populate message field for structured (kv) logs

### DIFF
--- a/user-data-store-server/src/main/java/com/wultra/security/userdatastore/controller/AttachmentController.java
+++ b/user-data-store-server/src/main/java/com/wultra/security/userdatastore/controller/AttachmentController.java
@@ -67,9 +67,9 @@ class AttachmentController {
     )
     @GetMapping("/attachments")
     public ObjectResponse<AttachmentResponse> fetchAttachments(@NotBlank @Size(max = 255) @RequestParam String userId, @NotBlank @Size(max = 255) @RequestParam String documentId) {
-        logger.info("", action("fetchAttachments"), stateInitiated(), kv("userId", userId), kv("documentId", documentId));
+        logger.info("Fetch attachments initiated", action("fetchAttachments"), stateInitiated(), kv("userId", userId), kv("documentId", documentId));
         final AttachmentResponse attachments = attachmentService.fetchAttachments(userId, Optional.ofNullable(documentId));
-        logger.info("", action("fetchAttachments"), stateSucceeded(), kv("userId", userId), kv("documentId", documentId));
+        logger.info("Fetch attachments succeeded", action("fetchAttachments"), stateSucceeded(), kv("userId", userId), kv("documentId", documentId));
         return new ObjectResponse<>(attachments);
     }
 
@@ -85,9 +85,9 @@ class AttachmentController {
     )
     @PostMapping("/admin/attachments")
     public ObjectResponse<AttachmentCreateResponse> createAttachment(@Valid @RequestBody final ObjectRequest<AttachmentCreateRequest> request) {
-        logger.info("", action("createAttachment"), stateInitiated(), kv("userId", request.getRequestObject().userId()));
+        logger.info("Create attachment initiated", action("createAttachment"), stateInitiated(), kv("userId", request.getRequestObject().userId()));
         final AttachmentCreateResponse response = attachmentService.createAttachment(request.getRequestObject());
-        logger.info("", action("createAttachment"), stateSucceeded(), kv("userId", request.getRequestObject().userId()));
+        logger.info("Create attachment succeeded", action("createAttachment"), stateSucceeded(), kv("userId", request.getRequestObject().userId()));
         return new ObjectResponse<>(response);
     }
 
@@ -103,9 +103,9 @@ class AttachmentController {
     )
     @PutMapping("/admin/attachments/{attachmentId}")
     public Response updateAttachment(@NotBlank @Size(max = 36) @PathVariable("attachmentId") String attachmentId, @Valid @RequestBody final ObjectRequest<AttachmentUpdateRequest> request) {
-        logger.info("", action("updateAttachment"), stateInitiated(), kv("attachmentId", attachmentId));
+        logger.info("Update attachment initiated", action("updateAttachment"), stateInitiated(), kv("attachmentId", attachmentId));
         attachmentService.updateAttachment(attachmentId, request.getRequestObject());
-        logger.info("", action("updateAttachment"), stateSucceeded(), kv("attachmentId", attachmentId));
+        logger.info("Update attachment succeeded", action("updateAttachment"), stateSucceeded(), kv("attachmentId", attachmentId));
         return new Response();
     }
 
@@ -122,9 +122,9 @@ class AttachmentController {
     )
     @DeleteMapping("/admin/attachments")
     public Response deleteAttachments(@NotBlank @Size(max = 255) @RequestParam String userId, @Size(max = 255) @RequestParam(required = false) String documentId) {
-        logger.info("", action("deleteAttachments"), stateInitiated(), kv("userId", userId), kv("documentId", documentId));
+        logger.info("Delete attachments initiated", action("deleteAttachments"), stateInitiated(), kv("userId", userId), kv("documentId", documentId));
         attachmentService.deleteAttachments(userId, Optional.ofNullable(documentId));
-        logger.info("", action("deleteAttachments"), stateSucceeded(), kv("userId", userId), kv("documentId", documentId));
+        logger.info("Delete attachments succeeded", action("deleteAttachments"), stateSucceeded(), kv("userId", userId), kv("documentId", documentId));
         return new Response();
     }
 

--- a/user-data-store-server/src/main/java/com/wultra/security/userdatastore/controller/ClaimsController.java
+++ b/user-data-store-server/src/main/java/com/wultra/security/userdatastore/controller/ClaimsController.java
@@ -64,9 +64,9 @@ class ClaimsController {
     )
     @GetMapping("/claims")
     public ObjectResponse<Object> fetchClaims(@NotBlank @Size(max = 255) @RequestParam String userId, @Size(max = 255) @RequestParam(required = false) String claim) {
-        logger.info("", action("fetchClaims"), stateInitiated(), kv("userId", userId), kv("claim", claim));
+        logger.info("Fetch claims initiated", action("fetchClaims"), stateInitiated(), kv("userId", userId), kv("claim", claim));
         final Object claims = claimsService.fetchClaims(userId, Optional.ofNullable(claim));
-        logger.info("", action("fetchClaims"), stateSucceeded(), kv("userId", userId), kv("claim", claim));
+        logger.info("Fetch claims succeeded", action("fetchClaims"), stateSucceeded(), kv("userId", userId), kv("claim", claim));
         return new ObjectResponse<>(claims);
     }
 
@@ -83,9 +83,9 @@ class ClaimsController {
     )
     @PostMapping("/admin/claims")
     public Response createClaims(@NotBlank @Size(max = 255) @RequestParam String userId, @RequestBody final Object claims) {
-        logger.info("", action("createClaims"), stateInitiated(), kv("userId", userId));
+        logger.info("Create claims initiated", action("createClaims"), stateInitiated(), kv("userId", userId));
         claimsService.createClaims(userId, claims);
-        logger.info("", action("createClaims"), stateSucceeded(), kv("userId", userId));
+        logger.info("Create claims succeeded", action("createClaims"), stateSucceeded(), kv("userId", userId));
         return new Response();
     }
 
@@ -102,9 +102,9 @@ class ClaimsController {
     )
     @PutMapping("/admin/claims")
     public Response updateClaims(@NotBlank @Size(max = 255) @RequestParam String userId, @RequestBody final Object claims) {
-        logger.info("", action("updateClaims"), stateInitiated(), kv("userId", userId));
+        logger.info("Update claims initiated", action("updateClaims"), stateInitiated(), kv("userId", userId));
         claimsService.updateClaims(userId, claims);
-        logger.info("", action("updateClaims"), stateSucceeded(), kv("userId", userId));
+        logger.info("Update claims succeeded", action("updateClaims"), stateSucceeded(), kv("userId", userId));
         return new Response();
     }
 
@@ -120,9 +120,9 @@ class ClaimsController {
     )
     @DeleteMapping("/admin/claims")
     public Response deleteClaims(@NotBlank @Size(max = 255) @RequestParam String userId, @Size(max = 255) @RequestParam(required = false) String claim) {
-        logger.info("", action("deleteClaims"), stateInitiated(), kv("userId", userId), kv("claim", claim));
+        logger.info("Delete claims initiated", action("deleteClaims"), stateInitiated(), kv("userId", userId), kv("claim", claim));
         claimsService.deleteClaims(userId, claim);
-        logger.info("", action("deleteClaims"), stateSucceeded(), kv("userId", userId), kv("claim", claim));
+        logger.info("Delete claims succeeded", action("deleteClaims"), stateSucceeded(), kv("userId", userId), kv("claim", claim));
         return new Response();
     }
 }

--- a/user-data-store-server/src/main/java/com/wultra/security/userdatastore/controller/DocumentController.java
+++ b/user-data-store-server/src/main/java/com/wultra/security/userdatastore/controller/DocumentController.java
@@ -94,7 +94,7 @@ class DocumentController {
             @Size(max = 255) @RequestParam(required = false) String documentType,
             @RequestParam(required = false) List<String> attributes) {
 
-        logger.info("", action("fetchDocuments"), stateInitiated(), kv("userId", userId), kv("documentId", documentId), kv("documentType", documentType), kv("attributes", attributes));
+        logger.info("Fetch documents initiated", action("fetchDocuments"), stateInitiated(), kv("userId", userId), kv("documentId", documentId), kv("documentType", documentType), kv("attributes", attributes));
         final var request = DocumentService.DocumentsRequest.builder()
                 .userId(userId)
                 .documentId(documentId)
@@ -102,7 +102,7 @@ class DocumentController {
                 .attributes(parseAttributes(attributes))
                 .build();
         final DocumentResponse documents = documentService.fetchDocuments(request);
-        logger.info("", action("fetchDocuments"), stateSucceeded(), kv("count", documents.documents().size()));
+        logger.info("Fetch documents succeeded", action("fetchDocuments"), stateSucceeded(), kv("count", documents.documents().size()));
         return new ObjectResponse<>(documents);
     }
 
@@ -142,9 +142,9 @@ class DocumentController {
     )
     @PostMapping("/admin/documents")
     public ObjectResponse<DocumentCreateResponse> createDocument(@Valid @RequestBody final ObjectRequest<DocumentCreateRequest> request) {
-        logger.info("", action("createDocument"), stateInitiated(), kv("userId", request.getRequestObject().userId()));
+        logger.info("Create document initiated", action("createDocument"), stateInitiated(), kv("userId", request.getRequestObject().userId()));
         final DocumentCreateResponse response = documentService.createDocument(request.getRequestObject());
-        logger.info("", action("createDocument"), stateSucceeded(), kv("userId", request.getRequestObject().userId()));
+        logger.info("Create document succeeded", action("createDocument"), stateSucceeded(), kv("userId", request.getRequestObject().userId()));
         return new ObjectResponse<>(response);
     }
 
@@ -161,9 +161,9 @@ class DocumentController {
     )
     @PutMapping("/admin/documents/{documentId}")
     public Response updateDocument(@NotBlank @Size(max = 36) @PathVariable("documentId") String documentId, @Valid @RequestBody final ObjectRequest<DocumentUpdateRequest> request) {
-        logger.info("", action("updateDocument"), stateInitiated(), kv("userId", request.getRequestObject().userId()), kv("documentId", documentId));
+        logger.info("Update document initiated", action("updateDocument"), stateInitiated(), kv("userId", request.getRequestObject().userId()), kv("documentId", documentId));
         documentService.updateDocument(documentId, request.getRequestObject());
-        logger.info("", action("updateDocument"), stateSucceeded(), kv("userId", request.getRequestObject().userId()), kv("documentId", documentId));
+        logger.info("Update document succeeded", action("updateDocument"), stateSucceeded(), kv("userId", request.getRequestObject().userId()), kv("documentId", documentId));
         return new Response();
     }
 
@@ -180,9 +180,9 @@ class DocumentController {
     )
     @DeleteMapping("/admin/documents")
     public Response deleteDocuments(@NotBlank @Size(max = 255) @RequestParam String userId, @Size(max = 255) @RequestParam(required = false) String documentId) {
-        logger.info("", action("deleteDocuments"), stateInitiated(), kv("userId", userId), kv("documentId", documentId));
+        logger.info("Delete documents initiated", action("deleteDocuments"), stateInitiated(), kv("userId", userId), kv("documentId", documentId));
         documentService.deleteDocuments(userId, Optional.ofNullable(documentId));
-        logger.info("", action("deleteDocuments"), stateSucceeded(), kv("userId", userId), kv("documentId", documentId));
+        logger.info("Delete documents succeeded", action("deleteDocuments"), stateSucceeded(), kv("userId", userId), kv("documentId", documentId));
         return new Response();
     }
 

--- a/user-data-store-server/src/main/java/com/wultra/security/userdatastore/controller/PhotoController.java
+++ b/user-data-store-server/src/main/java/com/wultra/security/userdatastore/controller/PhotoController.java
@@ -70,9 +70,9 @@ class PhotoController {
     )
     @GetMapping("/photos")
     public ObjectResponse<PhotoResponse> fetchPhotos(@NotBlank @Size(max = 255) @RequestParam String userId, @NotBlank @Size(max = 255) @RequestParam String documentId) {
-        logger.info("", action("fetchPhotos"), stateInitiated(), kv("userId", userId), kv("documentId", documentId));
+        logger.info("Fetch photos initiated", action("fetchPhotos"), stateInitiated(), kv("userId", userId), kv("documentId", documentId));
         final PhotoResponse photos = photoService.fetchPhotos(userId, Optional.ofNullable(documentId));
-        logger.info("", action("fetchPhotos"), stateSucceeded(), kv("userId", userId), kv("documentId", documentId));
+        logger.info("Fetch photos succeeded", action("fetchPhotos"), stateSucceeded(), kv("userId", userId), kv("documentId", documentId));
         return new ObjectResponse<>(photos);
     }
 
@@ -88,9 +88,9 @@ class PhotoController {
     )
     @PostMapping("/admin/photos")
     public ObjectResponse<PhotoCreateResponse> createPhoto(@Valid @RequestBody final ObjectRequest<PhotoCreateRequest> request) {
-        logger.info("", action("createPhoto"), stateInitiated(), kv("userId", request.getRequestObject().userId()), kv("documentId", request.getRequestObject().documentId()));
+        logger.info("Create photo initiated", action("createPhoto"), stateInitiated(), kv("userId", request.getRequestObject().userId()), kv("documentId", request.getRequestObject().documentId()));
         final PhotoCreateResponse response = photoService.createPhoto(request.getRequestObject());
-        logger.info("", action("createPhoto"), stateSucceeded(), kv("userId", request.getRequestObject().userId()), kv("documentId", request.getRequestObject().documentId()));
+        logger.info("Create photo succeeded", action("createPhoto"), stateSucceeded(), kv("userId", request.getRequestObject().userId()), kv("documentId", request.getRequestObject().documentId()));
         return new ObjectResponse<>(response);
     }
 
@@ -106,9 +106,9 @@ class PhotoController {
     )
     @PutMapping("/admin/photos/{photoId}")
     public Response updatePhoto(@NotBlank @Size(max = 36) @PathVariable("photoId") String photoId, @Valid @RequestBody final ObjectRequest<PhotoUpdateRequest> request) {
-        logger.info("", action("createPhoto"), stateInitiated(), kv("photoId", photoId));
+        logger.info("Create photo initiated", action("createPhoto"), stateInitiated(), kv("photoId", photoId));
         photoService.updatePhoto(photoId, request.getRequestObject());
-        logger.info("", action("createPhoto"), stateSucceeded(), kv("photoId", photoId));
+        logger.info("Create photo succeeded", action("createPhoto"), stateSucceeded(), kv("photoId", photoId));
         return new Response();
     }
 
@@ -125,9 +125,9 @@ class PhotoController {
     )
     @DeleteMapping("/admin/photos")
     public Response deletePhotos(@NotBlank @Size(max = 255) @RequestParam String userId, @Size(max = 255) @RequestParam(required = false) String documentId) {
-        logger.info("", action("deletePhotos"), stateInitiated(), kv("userId", userId), kv("documentId", documentId));
+        logger.info("Delete photos initiated", action("deletePhotos"), stateInitiated(), kv("userId", userId), kv("documentId", documentId));
         photoService.deletePhotos(userId, Optional.ofNullable(documentId));
-        logger.info("", action("deletePhotos"), stateSucceeded(), kv("userId", userId), kv("documentId", documentId));
+        logger.info("Delete photos succeeded", action("deletePhotos"), stateSucceeded(), kv("userId", userId), kv("documentId", documentId));
         return new Response();
     }
 
@@ -143,9 +143,9 @@ class PhotoController {
     )
     @PostMapping("/admin/photos/import")
     public ObjectResponse<PhotosImportResponse> importPhotos(@Valid @RequestBody final ObjectRequest<PhotosImportRequest> request) {
-        logger.info("", action("importPhotos"), stateInitiated());
+        logger.info("Import photos initiated", action("importPhotos"), stateInitiated());
         final PhotosImportResponse response = photoService.importPhotos(request.getRequestObject());
-        logger.info("", action("importPhotos"), stateSucceeded());
+        logger.info("Import photos succeeded", action("importPhotos"), stateSucceeded());
         return new ObjectResponse<>(response);
     }
 
@@ -161,9 +161,9 @@ class PhotoController {
     )
     @PostMapping("/admin/photos/import/csv")
     public Response importPhotosCsv(@Valid @RequestBody final ObjectRequest<PhotosImportCsvRequest> request) {
-        logger.info("", action("importPhotosCsv"), stateInitiated());
+        logger.info("Import photos csv initiated", action("importPhotosCsv"), stateInitiated());
         photoService.importPhotosCsv(request.getRequestObject());
-        logger.info("", action("importPhotosCsv"), stateSucceeded());
+        logger.info("Import photos csv succeeded", action("importPhotosCsv"), stateSucceeded());
         return new Response();
     }
 

--- a/user-data-store-server/src/main/java/com/wultra/security/userdatastore/controller/UserClaimsController.java
+++ b/user-data-store-server/src/main/java/com/wultra/security/userdatastore/controller/UserClaimsController.java
@@ -63,9 +63,9 @@ class UserClaimsController {
     )
     @GetMapping("/private/user-claims")
     public ObjectResponse<Object> fetchClaims(@NotBlank @Size(max = 255) @RequestParam String userId) {
-        logger.info("", action("fetchClaims"), stateInitiated(), kv("userId", userId));
+        logger.info("Fetch claims initiated", action("fetchClaims"), stateInitiated(), kv("userId", userId));
         final Object userClaims = userClaimsService.fetchUserClaims(userId);
-        logger.info("", action("fetchClaims"), stateSucceeded(), kv("userId", userId));
+        logger.info("Fetch claims succeeded", action("fetchClaims"), stateSucceeded(), kv("userId", userId));
         return new ObjectResponse<>(userClaims);
     }
 
@@ -82,9 +82,9 @@ class UserClaimsController {
     )
     @PostMapping("/public/user-claims")
     public Response storeClaims(@NotBlank @Size(max = 255) @RequestParam String userId, @RequestBody final Object claims) {
-        logger.info("", action("storeClaims"), stateInitiated(), kv("userId", userId));
+        logger.info("Store claims initiated", action("storeClaims"), stateInitiated(), kv("userId", userId));
         userClaimsService.createOrUpdateUserClaims(userId, claims);
-        logger.info("", action("storeClaims"), stateSucceeded(), kv("userId", userId));
+        logger.info("Store claims succeeded", action("storeClaims"), stateSucceeded(), kv("userId", userId));
         return new Response();
     }
 
@@ -100,9 +100,9 @@ class UserClaimsController {
     )
     @DeleteMapping("/public/user-claims")
     public Response deleteClaims(@NotBlank @Size(max = 255) @RequestParam String userId) {
-        logger.info("", action("deleteClaims"), stateInitiated(), kv("userId", userId));
+        logger.info("Delete claims initiated", action("deleteClaims"), stateInitiated(), kv("userId", userId));
         userClaimsService.deleteUserClaims(userId);
-        logger.info("", action("deleteClaims"), stateSucceeded(), kv("userId", userId));
+        logger.info("Delete claims succeeded", action("deleteClaims"), stateSucceeded(), kv("userId", userId));
         return new Response();
     }
 }

--- a/user-data-store-server/src/main/java/com/wultra/security/userdatastore/errorhandling/DefaultExceptionHandler.java
+++ b/user-data-store-server/src/main/java/com/wultra/security/userdatastore/errorhandling/DefaultExceptionHandler.java
@@ -56,7 +56,7 @@ class DefaultExceptionHandler {
     @ExceptionHandler(NoResourceFoundException.class)
     @ResponseStatus(HttpStatus.NOT_FOUND)
     public ErrorResponse handleNoResourceFoundException(final NoResourceFoundException e) {
-        logger.warn("", action("handleNoResourceFound"), stateFailed(), e);
+        logger.warn("Handle no resource found failed", action("handleNoResourceFound"), stateFailed(), e);
         return new ErrorResponse("ERROR_NOT_FOUND", "Resource not found.");
     }
 
@@ -69,7 +69,7 @@ class DefaultExceptionHandler {
     @ExceptionHandler(EncryptionException.class)
     @ResponseStatus(HttpStatus.CONFLICT)
     public ErrorResponse handleEncryptionException(final EncryptionException e) {
-        logger.warn("", action("handleEncryptionException"), stateFailed(), e);
+        logger.warn("Handle encryption exception failed", action("handleEncryptionException"), stateFailed(), e);
         return new ErrorResponse("ENCRYPTION_ERROR", e.getMessage());
     }
 
@@ -87,7 +87,7 @@ class DefaultExceptionHandler {
             IllegalArgumentException.class})
     @ResponseStatus(HttpStatus.BAD_REQUEST)
     public ErrorResponse handleInvalidRequestException(final Exception e) {
-        logger.warn("", action("handleInvalidRequest"), stateFailed(), e);
+        logger.warn("Handle invalid request failed", action("handleInvalidRequest"), stateFailed(), e);
         return new ErrorResponse("INVALID_REQUEST", e.getMessage());
     }
 
@@ -100,7 +100,7 @@ class DefaultExceptionHandler {
     @ExceptionHandler(ResourceNotFoundException.class)
     @ResponseStatus(HttpStatus.BAD_REQUEST)
     public ErrorResponse handleNotFoundException(final ResourceNotFoundException e) {
-        logger.warn("", action("handleNotFoundException"), stateFailed(), e);
+        logger.warn("Handle not found exception failed", action("handleNotFoundException"), stateFailed(), e);
         return new ErrorResponse("NOT_FOUND", e.getMessage());
     }
 
@@ -113,7 +113,7 @@ class DefaultExceptionHandler {
     @ExceptionHandler(ResourceAlreadyExistsException.class)
     @ResponseStatus(HttpStatus.BAD_REQUEST)
     public ErrorResponse handleAlreadyExistsException(final ResourceAlreadyExistsException e) {
-        logger.warn("", action("handleAlreadyExistsException"), stateFailed(), e);
+        logger.warn("Handle already exists exception failed", action("handleAlreadyExistsException"), stateFailed(), e);
         return new ErrorResponse("ALREADY_EXISTS", e.getMessage());
     }
 

--- a/user-data-store-server/src/main/java/com/wultra/security/userdatastore/service/EncryptionService.java
+++ b/user-data-store-server/src/main/java/com/wultra/security/userdatastore/service/EncryptionService.java
@@ -195,7 +195,7 @@ public class EncryptionService {
             baos.write(encrypted);
             return Base64.getEncoder().encodeToString(baos.toByteArray());
         } catch (GenericCryptoException | CryptoProviderException | InvalidKeyException | IOException e) {
-            logger.error("", action("encryptClaims"), stateFailed(), kv("userId", userId), e);
+            logger.error("Encrypt claims failed", action("encryptClaims"), stateFailed(), kv("userId", userId), e);
             throw new EncryptionException("Unable to encrypt claims for user ID: " + userId, e);
         }
     }
@@ -218,7 +218,7 @@ public class EncryptionService {
             final byte[] decryptedClaims = aesEncryptionUtils.decrypt(encryptedClaims, iv, secretKey);
             return new String(decryptedClaims, StandardCharsets.UTF_8);
         } catch (InvalidKeyException | GenericCryptoException | CryptoProviderException e) {
-            logger.error("", action("decryptClaims"), stateFailed(), kv("userId", userId), e);
+            logger.error("Decrypt claims failed", action("decryptClaims"), stateFailed(), kv("userId", userId), e);
             throw new EncryptionException("Unable to decrypt claims for user ID: " + userId, e);
         }
     }


### PR DESCRIPTION
## Summary

Fixes #434 (part of epic wultra/tasklist#992).

Structured log calls were logging an **empty message string**, e.g.:

```java
logger.info("", action("fetchClaims"), stateInitiated(), kv("userId", userId));
```

Because the Logstash encoder is configured with `<omitEmptyFields>true</omitEmptyFields>`, the empty `message` field was dropped and indexed as `null` in Elasticsearch. Old-style logs (with a real message) were unaffected.

## Change

Add a concise, human-readable message to every structured log call, derived deterministically from the existing `action` name + `state`. All structured arguments (`action(...)`, `state...()`, `kv(...)`, exceptions) are left **unchanged**, so existing Elastic dashboards/queries keyed on those fields keep working.

Convention (aligned with enrollment-server PR wultra/enrollment-server#1820): the `action("...")` name is rendered in sentence case followed by the state word:

```java
logger.info("Fetch claims initiated", action("fetchClaims"), stateInitiated(), kv("userId", userId));
```

| state | message |
|---|---|
| `initiated` | `<Action> initiated` |
| `succeeded` | `<Action> succeeded` |
| `failed` | `<Action> failed` |

## Scope

49 call sites across 7 files: 5 controllers (`Claims`, `Photo`, `UserClaims`, `Document`, `Attachment`), `DefaultExceptionHandler`, and `EncryptionService`. No logback/encoder config change (`omitEmptyFields=true` stays).

## Validation

- `BUILD SUCCESS` (compile, JDK 25).
- No tests assert on log output.
